### PR TITLE
update: copy proposal feature

### DIFF
--- a/app/components/proposals/form.tsx
+++ b/app/components/proposals/form.tsx
@@ -62,20 +62,22 @@ export default function ProposalForm({ cfp }: ProposalFormProps) {
       proposal.set('lang', locale);
       setProposal(proposal);
     } catch (error) {
-      console.error('提案のコピー中にエラーが発生しました:', error);
       setMessage({
         type: 'error',
         messages: ['提案のコピーに失敗しました。']
       });
+      setTimeout(() => {
+        setMessage(undefined);
+      }, 3000);
     }
   }
 
   const getProposal = async () => {
-    if (!id && !copy) {
-      return setProposal(new Parse.Object('Proposal'));
-    }
     if (copy) {
       return copyProposal(copy);
+    }
+    if (!id) {
+      return setProposal(new Parse.Object('Proposal'));
     }
     const query = new Parse.Query('Proposal');
     query.include('cfp');

--- a/app/components/proposals/form.tsx
+++ b/app/components/proposals/form.tsx
@@ -38,20 +38,36 @@ export default function ProposalForm({ cfp }: ProposalFormProps) {
   }, [cfp]);
 
   const copyProposal = async (id: string) => {
-    const query = new Parse.Query('Proposal');
-    const copy = await query.get(id);
-    const proposal = new Parse.Object('Proposal');
-    if (!copy) return;
-    for (const key in copy.toJSON()) {
-      if (['objectId', 'createdAt', 'updatedAt', 'ACL', 'user', 'cfp', 'deadline', 'is_enabled', 'review', 'key', 'responseStatus', 'rating', 'status'].includes(key)) {
-        continue;
+    try {
+      const query = new Parse.Query('Proposal');
+      const copy = await query.get(id);
+      const proposal = new Parse.Object('Proposal');
+      if (!copy) return;
+
+      // より包括的な除外フィールドリスト
+      for (const key in copy.toJSON()) {
+        if ([
+          'objectId', 'createdAt', 'updatedAt', 'ACL',
+          'user', 'cfp', 'deadline', 'is_enabled',
+          'review', 'key', 'responseStatus', 'rating',
+          'status', 'sessionId', 'sessionKey'
+        ].includes(key)) {
+          continue;
+        }
+        proposal.set(key, copy.get(key));
       }
-      proposal.set(key, copy.get(key));
+
+      proposal.set('user', user);
+      proposal.set('cfp', cfp);
+      proposal.set('lang', locale);
+      setProposal(proposal);
+    } catch (error) {
+      console.error('提案のコピー中にエラーが発生しました:', error);
+      setMessage({
+        type: 'error',
+        messages: ['提案のコピーに失敗しました。']
+      });
     }
-    proposal.set('user', user);
-    proposal.set('cfp', cfp);
-    proposal.set('lang', locale);
-    setProposal(proposal);
   }
 
   const getProposal = async () => {

--- a/app/components/proposals/response.tsx
+++ b/app/components/proposals/response.tsx
@@ -1,5 +1,3 @@
-import Form from '../form/';
-import { useSchema } from '~/schemas/proposal';
 import { setLang } from '~/utils/i18n';
 import { Link, useParams } from '@remix-run/react';
 import { useContext, useEffect, useState } from 'react';
@@ -15,10 +13,8 @@ export default function ProposalForm() {
   const params = useParams();
   const { locale, id } = params;
   const { t } = setLang(locale!);
-  const schema = useSchema(locale!);
   const [proposal, setProposal] = useState<Parse.Object | undefined>();
   const [message, setMessage] = useState<MessageProps | undefined>(undefined);
-  const [status, setStatus] = useState<string>('');
 
   useEffect(() => {
     getProposal();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 既存の提案をコピーして新規提案を作成できる機能を追加しました。提案一覧から「コピー」アイコンをクリックすると、内容を引き継いだ新規提案作成画面に移動します。
  - 提案の新規作成ボタンは、現在有効な公募期間（CFP）が存在する場合のみ表示されます。

- **改善**
  - 公募期間外は提案の編集や新規作成ができないようにUIを調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->